### PR TITLE
Update express-basic-auth dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "connect-static-file": "=1.1.2",
     "docopt": "=0.6.2",
     "express": "=4.14.1",
-    "express-basic-auth": "=0.3.2",
+    "express-basic-auth": "^1.0.0",
     "express-ip-access-control": "=1.0.5",
     "express-winston": "=2.2.0",
     "helmet": "=3.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "connect-static-file": "=1.1.2",
     "docopt": "=0.6.2",
     "express": "=4.14.1",
-    "express-basic-auth": "^1.0.0",
+    "express-basic-auth": "=1.0.1",
     "express-ip-access-control": "=1.0.5",
     "express-winston": "=2.2.0",
     "helmet": "=3.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "connect-static-file": "=1.1.2",
     "docopt": "=0.6.2",
     "express": "=4.14.1",
-    "express-basic-auth": "=1.0.1",
+    "express-basic-auth": "1.0.1",
     "express-ip-access-control": "=1.0.5",
     "express-winston": "=2.2.0",
     "helmet": "=3.4.0",


### PR DESCRIPTION
I noticed that you are using an old version of `express-basic-auth`. Version 1.0.0 is fully compatible with the one you are using now, so using it will enable you to get the latest updates, features and bugfixes without having to change any code.

It is also safe and recommended to use a carret dependency here, as all 1.x versions are guaranteed to be compatible to 1.0.0 and 0.x.